### PR TITLE
feat: impossible travel detection in Kratos module

### DIFF
--- a/.github/ISSUE_TEMPLATE/DESIGN-DOC.yml
+++ b/.github/ISSUE_TEMPLATE/DESIGN-DOC.yml
@@ -9,7 +9,7 @@ name: "Design Document"
 body:
   - attributes:
       value: |
-        Thank you for writing this design document. 
+        Thank you for writing this design document.
 
         One of the key elements of Ory's software engineering culture is the use of defining software designs through design docs. These are relatively informal documents that the primary author or authors of a software system or application create before they embark on the coding project. The design doc documents the high level implementation strategy and key design decisions with emphasis on the trade-offs that were considered during those decisions.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,7 +170,7 @@ request, go through this checklist:
 1. [Rebase](http://git-scm.com/book/en/Git-Branching-Rebasing) your local
    changes against the `master` branch.
 1. Run the full project test suite with the `go test -tags sqlite ./...` (or
-   equivalent) command and confirm that it passes.
+   equivalent) command and confirm that it passes. (*Docker is required)
 1. Run `make format`
 1. Add a descriptive prefix to commits. This ensures a uniform commit history
    and helps structure the changelog. Please refer to this
@@ -245,7 +245,7 @@ git checkout master
 git pull --rebase
 
 # Next you create a new feature branch off of master:
-git checkout my-feature-branch
+git checkout -b my-feature-branch
 
 # Now you do your work and commit your changes:
 git add -A

--- a/go.mod
+++ b/go.mod
@@ -118,6 +118,7 @@ require (
 	github.com/dgraph-io/ristretto/v2 v2.0.0 // indirect
 	github.com/jackc/pgx/v5 v5.6.0 // indirect
 	github.com/rjeczalik/notify v0.9.3 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	golang.org/x/term v0.27.0 // indirect
 	golang.org/x/time v0.8.0 // indirect
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -640,8 +640,6 @@ github.com/ory/pop/v6 v6.2.1-0.20241121111754-e5dfc0f3344b h1:BIzoOe2/wynZBQak1p
 github.com/ory/pop/v6 v6.2.1-0.20241121111754-e5dfc0f3344b/go.mod h1:okVAYKGtgunD/wbW3NGhZTndJCS+6FqO+cA89rQ4doc=
 github.com/ory/sessions v1.2.2-0.20220110165800-b09c17334dc2 h1:zm6sDvHy/U9XrGpixwHiuAwpp0Ock6khSVHkrv6lQQU=
 github.com/ory/sessions v1.2.2-0.20220110165800-b09c17334dc2/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
-github.com/ory/x v0.0.675 h1:K6GpVo99BXBFv2UiwMjySNNNqCFKGswynrt7vWQJFU8=
-github.com/ory/x v0.0.675/go.mod h1:zJmnDtKje2FCP4EeFvRsKk94XXiqKCSGJMZcirAfhUs=
 github.com/ory/x v0.0.689 h1:pMXmnw2aoHiq4jRX9xtGXqX+VU3USEwlUUbwNCxmiZQ=
 github.com/ory/x v0.0.689/go.mod h1:UpPgjobuyIyHh1pG4LxqmfMpuNOnzf2BzwyouwBeCk4=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=

--- a/internal/client-go/go.sum
+++ b/internal/client-go/go.sum
@@ -4,6 +4,7 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e h1:bRhVy7zSSasaqNksaRZiA5EEI+Ei4I1nO5Jh72wfHlg=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FYywz3ker1l1vDZRCRefw=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/selfservice/strategy/oidc/strategy_helper_test.go
+++ b/selfservice/strategy/oidc/strategy_helper_test.go
@@ -272,7 +272,7 @@ func newHydra(t *testing.T, subject *string, claims *idTokenClaims, scope *[]str
 		hydra, err := pool.RunWithOptions(&dockertest.RunOptions{
 			Repository: "oryd/hydra",
 			// Keep tag in sync with the version in ci.yaml
-			Tag: "v2.2.0@sha256:6c0f9195fe04ae16b095417b323881f8c9008837361160502e11587663b37c09",
+			Tag: "v2.2.0-rc.3",
 			Env: []string{
 				"DSN=memory",
 				fmt.Sprintf("URLS_SELF_ISSUER=http://localhost:%d/", publicPort),

--- a/selfservice/strategy/password/op_helpers_test.go
+++ b/selfservice/strategy/password/op_helpers_test.go
@@ -134,7 +134,7 @@ func newHydra(t *testing.T, loginUI string, consentUI string) (hydraAdmin string
 	hydraResource, err := pool.RunWithOptions(&dockertest.RunOptions{
 		Repository: "oryd/hydra",
 		// Keep tag in sync with the version in ci.yaml
-		Tag: "v2.2.0@sha256:6c0f9195fe04ae16b095417b323881f8c9008837361160502e11587663b37c09",
+		Tag: "v2.2.0-rc.3",
 		Env: []string{
 			"DSN=memory",
 			fmt.Sprintf("URLS_SELF_ISSUER=http://127.0.0.1:%d/", publicPort),

--- a/session/impossibletravel/crosscountry/durationestimator.go
+++ b/session/impossibletravel/crosscountry/durationestimator.go
@@ -1,0 +1,75 @@
+package crosscountry
+
+import (
+	"fmt"
+	"time"
+)
+
+// FIXME for sake of this example, those are only samples from: https://distancecalculator.globefeed.com/Distance_Between_Countries.asp
+var sampleDistances = map[crossCountryTravel]Kilometers{
+	{"US", "CA"}: 2_261.43,
+	{"JP", "FR"}: 9_849.63,
+	{"ZA", "UK"}: 9_880.13,
+}
+
+type SpeedBasedTravelsDurationEstimator struct {
+	distances map[crossCountryTravel]Kilometers
+	speed     KilometersPerHour
+}
+
+// NewAvgAirplaneTravelsEstimator creates a SpeedBasedTravelsDurationEstimator with an average flight speed of 567 mph.
+func NewAvgAirplaneTravelsEstimator() *SpeedBasedTravelsDurationEstimator {
+	// avg airplane speed based on https://distancecalculator.globefeed.com/Distance_Between_Countries.asp
+	return NewSampledSpeedBasedTravelsEstimator(MilesPerHour(567).toKilometersPerHour())
+}
+
+// NewSpeedOfLightTravelsEstimator creates a SpeedBasedTravelsDurationEstimator with a speed approximation equivalent to the speed of light.
+func NewSpeedOfLightTravelsEstimator() *SpeedBasedTravelsDurationEstimator {
+	// Approximate value of speed of light in Km / h
+	return NewSampledSpeedBasedTravelsEstimator(KilometersPerHour(1_080_000_000))
+}
+
+// NewSampledSpeedBasedTravelsEstimator creates a SpeedBasedTravelsDurationEstimator with predefined sample distances and a given speed.
+func NewSampledSpeedBasedTravelsEstimator(speed KilometersPerHour) *SpeedBasedTravelsDurationEstimator {
+	return NewSpeedBasedTravelsEstimator(sampleDistances, speed)
+}
+
+// NewSpeedBasedTravelsEstimator creates a new SpeedBasedTravelsDurationEstimator with provided distances and speed for travel duration calculations.
+func NewSpeedBasedTravelsEstimator(distances map[crossCountryTravel]Kilometers, speed KilometersPerHour) *SpeedBasedTravelsDurationEstimator {
+	return &SpeedBasedTravelsDurationEstimator{
+		distances: distances,
+		speed:     speed,
+	}
+}
+
+func (e *SpeedBasedTravelsDurationEstimator) EstimateTravelDuration(from Country, to Country) (time.Duration, error) {
+	distance, err := e.distanceBetween(from, to)
+	if err != nil {
+		return 0, err
+	}
+	return e.speed.durationFor(distance), nil
+}
+
+func (e *SpeedBasedTravelsDurationEstimator) distanceBetween(from Country, to Country) (Kilometers, error) {
+	travel := crossCountryTravel{from, to}
+	if distanceInKm, found := e.distances[travel]; found {
+		return distanceInKm, nil
+	}
+	reversedTravel := travel.reverse()
+	if distanceInKm, found := e.distances[reversedTravel]; found {
+		return distanceInKm, nil
+	}
+	return 0, fmt.Errorf("no data to estimate distance between %s and %s", from, to)
+}
+
+type crossCountryTravel struct {
+	from Country
+	to   Country
+}
+
+func (p crossCountryTravel) reverse() crossCountryTravel {
+	return crossCountryTravel{
+		from: p.to,
+		to:   p.from,
+	}
+}

--- a/session/impossibletravel/crosscountry/durationestimator_test.go
+++ b/session/impossibletravel/crosscountry/durationestimator_test.go
@@ -1,0 +1,92 @@
+package crosscountry
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestSpeedBasedTravelsDurationEstimator(t *testing.T) {
+
+	t.Run("should correctly estimate time based on distance and speed", func(t *testing.T) {
+
+		// given
+		distances := map[crossCountryTravel]Kilometers{
+			crossCountryTravel{from: "A", to: "B"}: 100,
+		}
+		speed := KilometersPerHour(10)
+
+		estimatorUT := NewSpeedBasedTravelsEstimator(distances, speed)
+
+		// when
+		estimation, err := estimatorUT.EstimateTravelDuration("A", "B")
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, 10*time.Hour, estimation)
+	})
+
+	t.Run("should correctly estimate time based on distance and speed for reverse direction", func(t *testing.T) {
+
+		// given
+		distances := map[crossCountryTravel]Kilometers{
+			crossCountryTravel{from: "A", to: "B"}: 100,
+		}
+		speed := KilometersPerHour(10)
+
+		estimatorUT := NewSpeedBasedTravelsEstimator(distances, speed)
+
+		// when
+		estimation, err := estimatorUT.EstimateTravelDuration("B", "A")
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, 10*time.Hour, estimation)
+	})
+
+	t.Run("should return error for unknown countries", func(t *testing.T) {
+
+		// given
+		distances := map[crossCountryTravel]Kilometers{
+			crossCountryTravel{from: "A", to: "B"}: 100,
+		}
+		speed := KilometersPerHour(10)
+
+		estimatorUT := NewSpeedBasedTravelsEstimator(distances, speed)
+
+		// when
+		estimation, err := estimatorUT.EstimateTravelDuration("B", "C")
+
+		// then
+		require.Error(t, err)
+		assert.Empty(t, estimation)
+	})
+
+	t.Run(fmt.Sprintf("with speed of light"), func(t *testing.T) {
+		estimatorUT := NewSpeedOfLightTravelsEstimator()
+		for travel := range sampleDistances {
+			t.Run(fmt.Sprintf("travel %v should last 0", travel), func(t *testing.T) {
+				// when
+				estimation, err := estimatorUT.EstimateTravelDuration(travel.from, travel.to)
+				// then
+				require.NoError(t, err)
+				assert.Empty(t, estimation)
+			})
+		}
+	})
+
+	t.Run(fmt.Sprintf("with avg speed of plane"), func(t *testing.T) {
+		estimatorUT := NewAvgAirplaneTravelsEstimator()
+		for travel := range sampleDistances {
+			t.Run(fmt.Sprintf("travel %v should last more than 0", travel), func(t *testing.T) {
+				// when
+				estimation, err := estimatorUT.EstimateTravelDuration(travel.from, travel.to)
+				// then
+				require.NoError(t, err)
+				assert.True(t, estimation > time.Duration(0))
+			})
+		}
+	})
+}

--- a/session/impossibletravel/crosscountry/models.go
+++ b/session/impossibletravel/crosscountry/models.go
@@ -1,0 +1,23 @@
+package crosscountry
+
+import "time"
+
+type Country string
+
+func (c Country) IsGeoLocated() bool {
+	return c != ""
+}
+
+type Kilometers float64
+type KilometersPerHour float64
+
+func (kph KilometersPerHour) durationFor(distance Kilometers) time.Duration {
+	durationInHours := float64(distance) / float64(kph)
+	return time.Duration(durationInHours) * time.Hour
+}
+
+type MilesPerHour float64
+
+func (mph MilesPerHour) toKilometersPerHour() KilometersPerHour {
+	return KilometersPerHour(float64(mph) * 1.609344)
+}

--- a/session/impossibletravel/detector/detector.go
+++ b/session/impossibletravel/detector/detector.go
@@ -1,0 +1,104 @@
+package detector
+
+import (
+	"github.com/gofrs/uuid"
+	log "github.com/sirupsen/logrus"
+	"time"
+)
+
+// Detector Detects visits, where an identity is accessed from two different geographic locations (eg countries) within an unreasonably short timeframe, suggesting that conventional travel between those locations would be impossible.
+type Detector[T GeoLocated] struct {
+	visitsAggregator        VisitsAggregator[T]
+	travelDurationEstimator TravelDurationEstimator[T]
+}
+
+func NewDetector[T GeoLocated](
+	visitsAggregator VisitsAggregator[T],
+	travelDurationEstimator TravelDurationEstimator[T],
+) *Detector[T] {
+	return &Detector[T]{
+		visitsAggregator:        visitsAggregator,
+		travelDurationEstimator: travelDurationEstimator,
+	}
+}
+
+type VisitsAggregator[T GeoLocated] interface {
+	GetPreviousVisitsAggregate(identityID uuid.UUID) (PreviousVisitsAggregate[T], error)
+	AggregateVisit(identityID uuid.UUID, visit Visit[T], detectionResult DetectionResult) error
+}
+
+type PreviousVisitsAggregate[T GeoLocated] interface {
+	GetLastLegitVisit() (Visit[T], bool)
+	IsLegitVisit(currentVisit Visit[T]) bool
+}
+
+type TravelDurationEstimator[T GeoLocated] interface {
+	EstimateTravelDuration(from T, to T) (time.Duration, error)
+}
+
+// DetectImpossibleTravel is a template method for impossible travel detection algorithm. Replaceable parts are extracted to appropriate strategies.
+func (d *Detector[T]) DetectImpossibleTravel(identityID uuid.UUID, currentVisit Visit[T]) DetectionResult {
+	log.Debugf("Starting impossible travel detection` for visit: `%v`...", currentVisit)
+	detectionResult := d.performDetection(identityID, currentVisit)
+	saveErr := d.visitsAggregator.AggregateVisit(identityID, currentVisit, detectionResult)
+	if saveErr != nil {
+		// generally detection succeed, so we still want to mark visit correctly,
+		// however data from current visit won't be available in the future detections, so reporting this as a warning
+		log.Warnf("Error aggregating current visit, so it won't be available in the future detections: %v", saveErr)
+	}
+	log.Debugf("Impossible travel detection finished with result `%v` for visit: `%v`", currentVisit, detectionResult)
+	return detectionResult
+}
+
+func (d *Detector[T]) performDetection(identityID uuid.UUID, currentVisit Visit[T]) DetectionResult {
+	previousVisitsAggregate, getErr := d.visitsAggregator.GetPreviousVisitsAggregate(identityID)
+	if getErr != nil {
+		log.Errorf("Error while getting previous visits aggregate: %v", getErr)
+		return DetectionError
+	}
+	lastLegitVisit, lastLegitVisitFound := previousVisitsAggregate.GetLastLegitVisit()
+	if !lastLegitVisitFound {
+		// it's a first visit so there is nothing to compare and no reason to not classify visit as legit
+		return LegitFirstVisit
+	}
+	// provides a mechanism to determine if a user's visit qualifies as legitimate basing on history data, without further evaluation of impossible travel conditions.
+	// It allows to mitigate the following false-positive cases:
+	// - User uses multiple devices and/or multiple applications from multiple IP addresses:
+	//   - VPN connection to corporate network with split tunnels:
+	//     -- some apps go directly with home IP address
+	//     -- some apps (eg using corporate GitHub) go through the VPN in different country
+	//
+	// - Zoom app may be used on a smartphone:
+	//   - IP address can change in seconds between a home Wi-Fi and ISP of a mobile network provider
+	//
+	// - Foreign travels:
+	//   - smartphone can change network between a Wi-Fi on given continent (eg in the office) and ISP of a mobile network provider from a home country connected via roaming
+	if previousVisitsAggregate.IsLegitVisit(currentVisit) {
+		return LegitVisit
+	}
+	travel := Travel[T]{
+		CurrentVisit:   currentVisit,
+		LastLegitVisit: lastLegitVisit,
+	}
+	if !lastLegitVisit.GeoLocation.IsGeoLocated() || !currentVisit.GeoLocation.IsGeoLocated() {
+		log.Warnf("Unable to verify travel duration because of insufficient Geo-location data: %v", travel)
+		return InsufficientData
+	}
+	unreasonablyShort, estimationErr := d.isUnreasonablyShort(travel)
+	if estimationErr != nil {
+		log.Errorf("Error while estimating travel duration: %v", estimationErr)
+		return DetectionError
+	}
+	if unreasonablyShort {
+		return ImpossibleTravel
+	}
+	return LegitTravel
+}
+
+func (d *Detector[T]) isUnreasonablyShort(travel Travel[T]) (bool, error) {
+	estimatedDuration, err := d.travelDurationEstimator.EstimateTravelDuration(travel.LastLegitVisit.GeoLocation, travel.CurrentVisit.GeoLocation)
+	if err != nil {
+		return false, err
+	}
+	return travel.Duration() < estimatedDuration, nil
+}

--- a/session/impossibletravel/detector/detector_test.go
+++ b/session/impossibletravel/detector/detector_test.go
@@ -1,0 +1,396 @@
+package detector
+
+import (
+	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestDetector(t *testing.T) {
+
+	t.Run("should return an error if fetching aggregate fails", func(t *testing.T) {
+
+		// given
+		visitsAggregator := &visitsAggregatorMock{}
+		travelDurationEstimator := &travelDurationEstimatorMock{}
+
+		previousVisitsAggregate := &previousVisitsAggregateMock{}
+
+		identityID := uuid.Must(uuid.NewV4())
+		currentVisit := Visit[anythingGeoLocated]{}
+
+		visitsAggregator.ExpectGetPreviousVisitsAggregate(identityID).Return(previousVisitsAggregate, errors.New("test error"))
+		visitsAggregator.ExpectAggregateVisit(identityID, currentVisit, DetectionError).Return(nil)
+
+		detectorUT := NewDetector(visitsAggregator, travelDurationEstimator)
+
+		// when
+		result := detectorUT.DetectImpossibleTravel(identityID, currentVisit)
+
+		// then
+		require.Equal(t, DetectionError, result)
+
+		visitsAggregator.AssertExpectations(t)
+		travelDurationEstimator.AssertExpectations(t)
+	})
+
+	t.Run("should detect legit first visit", func(t *testing.T) {
+
+		// given
+		visitsAggregator := &visitsAggregatorMock{}
+		travelDurationEstimator := &travelDurationEstimatorMock{}
+
+		previousVisitsAggregate := &previousVisitsAggregateMock{}
+		previousVisitsAggregate.ExpectGetLastLegitVisit().Return(Visit[anythingGeoLocated]{}, false)
+
+		identityID := uuid.Must(uuid.NewV4())
+		currentVisit := Visit[anythingGeoLocated]{}
+
+		visitsAggregator.ExpectGetPreviousVisitsAggregate(identityID).Return(previousVisitsAggregate, nil)
+		visitsAggregator.ExpectAggregateVisit(identityID, currentVisit, LegitFirstVisit).Return(nil)
+
+		detectorUT := NewDetector(visitsAggregator, travelDurationEstimator)
+
+		// when
+		result := detectorUT.DetectImpossibleTravel(identityID, currentVisit)
+
+		// then
+		require.Equal(t, LegitFirstVisit, result)
+
+		visitsAggregator.AssertExpectations(t)
+		travelDurationEstimator.AssertExpectations(t)
+	})
+
+	t.Run("should detect legit visit by preconditions", func(t *testing.T) {
+
+		// given
+		visitsAggregator := &visitsAggregatorMock{}
+		travelDurationEstimator := &travelDurationEstimatorMock{}
+		previousVisitsAggregate := &previousVisitsAggregateMock{}
+
+		identityID := uuid.Must(uuid.NewV4())
+		currentVisit := Visit[anythingGeoLocated]{}
+
+		previousVisitsAggregate.ExpectGetLastLegitVisit().Return(Visit[anythingGeoLocated]{}, true)
+		previousVisitsAggregate.ExpectIsLegitVisit(currentVisit).Return(true)
+
+		visitsAggregator.ExpectGetPreviousVisitsAggregate(identityID).Return(previousVisitsAggregate, nil)
+		visitsAggregator.ExpectAggregateVisit(identityID, currentVisit, LegitVisit).Return(nil)
+
+		detectorUT := NewDetector(visitsAggregator, travelDurationEstimator)
+
+		// when
+		result := detectorUT.DetectImpossibleTravel(identityID, currentVisit)
+
+		// then
+		require.Equal(t, LegitVisit, result)
+
+		visitsAggregator.AssertExpectations(t)
+		travelDurationEstimator.AssertExpectations(t)
+	})
+
+	t.Run("should not be able to detect impossible travel if last visit is not geo-located", func(t *testing.T) {
+
+		// given
+		visitsAggregator := &visitsAggregatorMock{}
+		travelDurationEstimator := &travelDurationEstimatorMock{}
+		previousVisitsAggregate := &previousVisitsAggregateMock{}
+
+		identityID := uuid.Must(uuid.NewV4())
+		deviceID := uuid.Must(uuid.NewV4())
+		currentVisit := Visit[anythingGeoLocated]{
+			Time:        time.Now(),
+			DeviceId:    deviceID,
+			GeoLocation: "location_1",
+		}
+		lastLegitVisit := Visit[anythingGeoLocated]{
+			Time:        time.Now(),
+			DeviceId:    deviceID,
+			GeoLocation: "",
+		}
+
+		previousVisitsAggregate.ExpectGetLastLegitVisit().Return(lastLegitVisit, true)
+		previousVisitsAggregate.ExpectIsLegitVisit(currentVisit).Return(false)
+
+		visitsAggregator.ExpectGetPreviousVisitsAggregate(identityID).Return(previousVisitsAggregate, nil)
+		visitsAggregator.ExpectAggregateVisit(identityID, currentVisit, InsufficientData).Return(nil)
+
+		detectorUT := NewDetector(visitsAggregator, travelDurationEstimator)
+
+		// when
+		result := detectorUT.DetectImpossibleTravel(identityID, currentVisit)
+
+		// then
+		require.Equal(t, InsufficientData, result)
+
+		visitsAggregator.AssertExpectations(t)
+		travelDurationEstimator.AssertExpectations(t)
+	})
+
+	t.Run("should not be able to detect impossible travel if current visit is not geo-located", func(t *testing.T) {
+
+		// given
+		visitsAggregator := &visitsAggregatorMock{}
+		travelDurationEstimator := &travelDurationEstimatorMock{}
+		previousVisitsAggregate := &previousVisitsAggregateMock{}
+
+		identityID := uuid.Must(uuid.NewV4())
+		deviceID := uuid.Must(uuid.NewV4())
+		currentVisit := Visit[anythingGeoLocated]{
+			Time:        time.Now(),
+			DeviceId:    deviceID,
+			GeoLocation: "",
+		}
+		lastLegitVisit := Visit[anythingGeoLocated]{
+			Time:        time.Now(),
+			DeviceId:    deviceID,
+			GeoLocation: "location_2",
+		}
+
+		previousVisitsAggregate.ExpectGetLastLegitVisit().Return(lastLegitVisit, true)
+		previousVisitsAggregate.ExpectIsLegitVisit(currentVisit).Return(false)
+
+		visitsAggregator.ExpectGetPreviousVisitsAggregate(identityID).Return(previousVisitsAggregate, nil)
+		visitsAggregator.ExpectAggregateVisit(identityID, currentVisit, InsufficientData).Return(nil)
+
+		detectorUT := NewDetector(visitsAggregator, travelDurationEstimator)
+
+		// when
+		result := detectorUT.DetectImpossibleTravel(identityID, currentVisit)
+
+		// then
+		require.Equal(t, InsufficientData, result)
+
+		visitsAggregator.AssertExpectations(t)
+		travelDurationEstimator.AssertExpectations(t)
+	})
+
+	t.Run("should detect impossible travel for unreasonable short period of time", func(t *testing.T) {
+
+		// given
+		visitsAggregator := &visitsAggregatorMock{}
+		travelDurationEstimator := &travelDurationEstimatorMock{}
+		previousVisitsAggregate := &previousVisitsAggregateMock{}
+
+		identityID := uuid.Must(uuid.NewV4())
+		deviceID := uuid.Must(uuid.NewV4())
+		currentVisit := Visit[anythingGeoLocated]{
+			Time:        time.Now(),
+			DeviceId:    deviceID,
+			GeoLocation: "location_1",
+		}
+		lastLegitVisit := Visit[anythingGeoLocated]{
+			Time:        time.Now().Add(1 * time.Minute),
+			DeviceId:    deviceID,
+			GeoLocation: "location_2",
+		}
+
+		previousVisitsAggregate.ExpectGetLastLegitVisit().Return(lastLegitVisit, true)
+		previousVisitsAggregate.ExpectIsLegitVisit(currentVisit).Return(false)
+
+		visitsAggregator.ExpectGetPreviousVisitsAggregate(identityID).Return(previousVisitsAggregate, nil)
+		visitsAggregator.ExpectAggregateVisit(identityID, currentVisit, ImpossibleTravel).Return(nil)
+
+		travelDurationEstimator.ExpectEstimateTravelDuration("location_2", "location_1").Return(time.Minute*10, nil)
+
+		detectorUT := NewDetector(visitsAggregator, travelDurationEstimator)
+
+		// when
+		result := detectorUT.DetectImpossibleTravel(identityID, currentVisit)
+
+		// then
+		require.Equal(t, ImpossibleTravel, result)
+
+		visitsAggregator.AssertExpectations(t)
+		travelDurationEstimator.AssertExpectations(t)
+	})
+
+	t.Run("should return detection error if travel duration estimation fails", func(t *testing.T) {
+
+		// given
+		visitsAggregator := &visitsAggregatorMock{}
+		travelDurationEstimator := &travelDurationEstimatorMock{}
+		previousVisitsAggregate := &previousVisitsAggregateMock{}
+
+		identityID := uuid.Must(uuid.NewV4())
+		deviceID := uuid.Must(uuid.NewV4())
+		currentVisit := Visit[anythingGeoLocated]{
+			Time:        time.Now(),
+			DeviceId:    deviceID,
+			GeoLocation: "location_1",
+		}
+		lastLegitVisit := Visit[anythingGeoLocated]{
+			Time:        time.Now().Add(1 * time.Minute),
+			DeviceId:    deviceID,
+			GeoLocation: "location_2",
+		}
+
+		previousVisitsAggregate.ExpectGetLastLegitVisit().Return(lastLegitVisit, true)
+		previousVisitsAggregate.ExpectIsLegitVisit(currentVisit).Return(false)
+
+		visitsAggregator.ExpectGetPreviousVisitsAggregate(identityID).Return(previousVisitsAggregate, nil)
+		visitsAggregator.ExpectAggregateVisit(identityID, currentVisit, DetectionError).Return(nil)
+
+		travelDurationEstimator.ExpectEstimateTravelDuration("location_2", "location_1").Return(0, errors.New("test error"))
+
+		detectorUT := NewDetector(visitsAggregator, travelDurationEstimator)
+
+		// when
+		result := detectorUT.DetectImpossibleTravel(identityID, currentVisit)
+
+		// then
+		require.Equal(t, DetectionError, result)
+
+		visitsAggregator.AssertExpectations(t)
+		travelDurationEstimator.AssertExpectations(t)
+	})
+
+	t.Run("should detect legit travel for reasonable period of time", func(t *testing.T) {
+
+		// given
+		visitsAggregator := &visitsAggregatorMock{}
+		travelDurationEstimator := &travelDurationEstimatorMock{}
+		previousVisitsAggregate := &previousVisitsAggregateMock{}
+
+		identityID := uuid.Must(uuid.NewV4())
+		deviceID := uuid.Must(uuid.NewV4())
+		currentVisit := Visit[anythingGeoLocated]{
+			Time:        time.Now(),
+			DeviceId:    deviceID,
+			GeoLocation: "location_1",
+		}
+		lastLegitVisit := Visit[anythingGeoLocated]{
+			Time:        time.Now().Add(2 * time.Minute),
+			DeviceId:    deviceID,
+			GeoLocation: "location_2",
+		}
+
+		previousVisitsAggregate.ExpectGetLastLegitVisit().Return(lastLegitVisit, true)
+		previousVisitsAggregate.ExpectIsLegitVisit(currentVisit).Return(false)
+
+		visitsAggregator.ExpectGetPreviousVisitsAggregate(identityID).Return(previousVisitsAggregate, nil)
+		visitsAggregator.ExpectAggregateVisit(identityID, currentVisit, LegitTravel).Return(nil)
+
+		travelDurationEstimator.ExpectEstimateTravelDuration("location_2", "location_1").Return(time.Minute*1, nil)
+
+		detectorUT := NewDetector(visitsAggregator, travelDurationEstimator)
+
+		// when
+		result := detectorUT.DetectImpossibleTravel(identityID, currentVisit)
+
+		// then
+		require.Equal(t, LegitTravel, result)
+
+		visitsAggregator.AssertExpectations(t)
+		travelDurationEstimator.AssertExpectations(t)
+	})
+
+	t.Run("should detect legit travel even if aggregation of current visit fails", func(t *testing.T) {
+
+		// given
+		visitsAggregator := &visitsAggregatorMock{}
+		travelDurationEstimator := &travelDurationEstimatorMock{}
+		previousVisitsAggregate := &previousVisitsAggregateMock{}
+
+		identityID := uuid.Must(uuid.NewV4())
+		deviceID := uuid.Must(uuid.NewV4())
+		currentVisit := Visit[anythingGeoLocated]{
+			Time:        time.Now(),
+			DeviceId:    deviceID,
+			GeoLocation: "location_1",
+		}
+		lastLegitVisit := Visit[anythingGeoLocated]{
+			Time:        time.Now().Add(2 * time.Minute),
+			DeviceId:    deviceID,
+			GeoLocation: "location_2",
+		}
+
+		previousVisitsAggregate.ExpectGetLastLegitVisit().Return(lastLegitVisit, true)
+		previousVisitsAggregate.ExpectIsLegitVisit(currentVisit).Return(false)
+
+		visitsAggregator.ExpectGetPreviousVisitsAggregate(identityID).Return(previousVisitsAggregate, nil)
+		visitsAggregator.ExpectAggregateVisit(identityID, currentVisit, LegitTravel).Return(errors.New("test error"))
+
+		travelDurationEstimator.ExpectEstimateTravelDuration("location_2", "location_1").Return(time.Minute*1, nil)
+
+		detectorUT := NewDetector(visitsAggregator, travelDurationEstimator)
+
+		// when
+		result := detectorUT.DetectImpossibleTravel(identityID, currentVisit)
+
+		// then
+		require.Equal(t, LegitTravel, result)
+
+		visitsAggregator.AssertExpectations(t)
+		travelDurationEstimator.AssertExpectations(t)
+	})
+}
+
+type anythingGeoLocated string
+
+func (l anythingGeoLocated) IsGeoLocated() bool {
+	return l != ""
+}
+
+type previousVisitsAggregateMock struct {
+	mock.Mock
+}
+
+func (m *previousVisitsAggregateMock) GetLastLegitVisit() (Visit[anythingGeoLocated], bool) {
+	args := m.Called()
+	v, _ := args.Get(0).(Visit[anythingGeoLocated])
+	return v, args.Bool(1)
+}
+
+func (m *previousVisitsAggregateMock) IsLegitVisit(currentVisit Visit[anythingGeoLocated]) bool {
+	args := m.Called(currentVisit)
+	return args.Bool(0)
+}
+
+func (m *previousVisitsAggregateMock) ExpectGetLastLegitVisit() *mock.Call {
+	return m.On("GetLastLegitVisit")
+}
+
+func (m *previousVisitsAggregateMock) ExpectIsLegitVisit(currentVisit Visit[anythingGeoLocated]) *mock.Call {
+	return m.On("IsLegitVisit", currentVisit)
+}
+
+type visitsAggregatorMock struct {
+	mock.Mock
+}
+
+func (m *visitsAggregatorMock) GetPreviousVisitsAggregate(identityID uuid.UUID) (PreviousVisitsAggregate[anythingGeoLocated], error) {
+	args := m.Called(identityID)
+	agg, _ := args.Get(0).(PreviousVisitsAggregate[anythingGeoLocated])
+	return agg, args.Error(1)
+}
+
+func (m *visitsAggregatorMock) AggregateVisit(identityID uuid.UUID, visit Visit[anythingGeoLocated], detectionResult DetectionResult) error {
+	args := m.Called(identityID, visit, detectionResult)
+	return args.Error(0)
+}
+
+func (m *visitsAggregatorMock) ExpectGetPreviousVisitsAggregate(identityID uuid.UUID) *mock.Call {
+	return m.On("GetPreviousVisitsAggregate", identityID)
+}
+
+func (m *visitsAggregatorMock) ExpectAggregateVisit(identityID uuid.UUID, visit Visit[anythingGeoLocated], detectionResult DetectionResult) *mock.Call {
+	return m.On("AggregateVisit", identityID, visit, detectionResult)
+}
+
+type travelDurationEstimatorMock struct {
+	mock.Mock
+}
+
+func (m *travelDurationEstimatorMock) EstimateTravelDuration(from anythingGeoLocated, to anythingGeoLocated) (time.Duration, error) {
+	args := m.Called(from, to)
+	d, _ := args.Get(0).(time.Duration)
+	return d, args.Error(1)
+}
+
+func (m *travelDurationEstimatorMock) ExpectEstimateTravelDuration(from anythingGeoLocated, to anythingGeoLocated) *mock.Call {
+	return m.On("EstimateTravelDuration", from, to)
+}

--- a/session/impossibletravel/detector/models.go
+++ b/session/impossibletravel/detector/models.go
@@ -1,0 +1,39 @@
+package detector
+
+import (
+	"github.com/gofrs/uuid"
+	"time"
+)
+
+// GeoLocated is marker interface to enforce types which may be Geo-located (like cities, or countries)
+type GeoLocated interface {
+	IsGeoLocated() bool
+}
+
+// Visit Describes user (identity) activity as Geo-located visit. Contains all data required to perform impossible travel detection.
+type Visit[T GeoLocated] struct {
+	Time        time.Time
+	DeviceId    uuid.UUID
+	GeoLocation T
+}
+
+// Travel describes travel between 2 Geo-located visits.
+type Travel[T GeoLocated] struct {
+	LastLegitVisit Visit[T]
+	CurrentVisit   Visit[T]
+}
+
+func (t Travel[T]) Duration() time.Duration {
+	return t.LastLegitVisit.Time.Sub(t.CurrentVisit.Time)
+}
+
+type DetectionResult string
+
+const (
+	LegitFirstVisit  DetectionResult = "LegitFirstVisit"
+	LegitVisit       DetectionResult = "LegitVisit"
+	LegitTravel      DetectionResult = "LegitTravel"
+	InsufficientData DetectionResult = "InsufficientData"
+	DetectionError   DetectionResult = "DetectionError"
+	ImpossibleTravel DetectionResult = "ImpossibleTravel"
+)

--- a/session/impossibletravel/knowndevices/visitsaggregate.go
+++ b/session/impossibletravel/knowndevices/visitsaggregate.go
@@ -1,0 +1,36 @@
+package knowndevices
+
+import (
+	"github.com/gofrs/uuid"
+	"github.com/ory/kratos/session/impossibletravel/detector"
+	"reflect"
+	"slices"
+)
+
+// FIXME Provide more reliable and secure implementation
+// FIXME Consider also usage of AuthenticatorAssuranceLevel, to accept visits which are very hard to break (eg recognize visit as legit for AuthenticatorAssuranceLevel >= `aal2`
+
+type VisitsAggregate[T detector.GeoLocated] struct {
+	knownDeviceIds []uuid.UUID
+	lastLegitVisit detector.Visit[T]
+}
+
+func NewVisitsAggregate[T detector.GeoLocated](
+	knownDeviceIds []uuid.UUID,
+	lastLegitVisit detector.Visit[T],
+) *VisitsAggregate[T] {
+	return &VisitsAggregate[T]{
+		knownDeviceIds: knownDeviceIds,
+		lastLegitVisit: lastLegitVisit,
+	}
+}
+
+func (a *VisitsAggregate[T]) GetLastLegitVisit() (detector.Visit[T], bool) {
+	var emptyVisit detector.Visit[T]
+	isZero := reflect.DeepEqual(a.lastLegitVisit, emptyVisit)
+	return a.lastLegitVisit, !isZero
+}
+
+func (a *VisitsAggregate[T]) IsLegitVisit(currentVisit detector.Visit[T]) bool {
+	return slices.Contains(a.knownDeviceIds, currentVisit.DeviceId)
+}

--- a/session/impossibletravel/knowndevices/visitsaggregate_test.go
+++ b/session/impossibletravel/knowndevices/visitsaggregate_test.go
@@ -1,0 +1,89 @@
+package knowndevices
+
+import (
+	"github.com/gofrs/uuid"
+	"github.com/ory/kratos/session/impossibletravel/detector"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestNewVisitsAggregate(t *testing.T) {
+
+	t.Run("should return last legit visit", func(t *testing.T) {
+
+		// given
+		lastLegitVisit := detector.Visit[anythingGeoLocated]{
+			Time:        time.Now(),
+			DeviceId:    uuid.Must(uuid.NewV4()),
+			GeoLocation: "Location",
+		}
+		visitsAggregateUT := NewVisitsAggregate(make([]uuid.UUID, 0), lastLegitVisit)
+
+		// when
+		actualLastLegitVisit, ok := visitsAggregateUT.GetLastLegitVisit()
+
+		// then
+		require.True(t, ok)
+		assert.Equal(t, lastLegitVisit, actualLastLegitVisit)
+	})
+
+	t.Run("should return empty last legit visit", func(t *testing.T) {
+
+		// given
+		lastLegitVisit := detector.Visit[anythingGeoLocated]{}
+		visitsAggregateUT := NewVisitsAggregate(make([]uuid.UUID, 0), lastLegitVisit)
+
+		// when
+		actualLastLegitVisit, ok := visitsAggregateUT.GetLastLegitVisit()
+
+		// then
+		require.False(t, ok)
+		assert.Equal(t, lastLegitVisit, actualLastLegitVisit)
+	})
+
+	t.Run("should recognize visit as legit if device is known", func(t *testing.T) {
+
+		// given
+		lastLegitVisit := detector.Visit[anythingGeoLocated]{}
+		currentVisit := detector.Visit[anythingGeoLocated]{
+			Time:        time.Now(),
+			DeviceId:    uuid.Must(uuid.NewV4()),
+			GeoLocation: "Location",
+		}
+		knownDevices := []uuid.UUID{currentVisit.DeviceId}
+		visitsAggregateUT := NewVisitsAggregate(knownDevices, lastLegitVisit)
+
+		// when
+		result := visitsAggregateUT.IsLegitVisit(currentVisit)
+
+		// then
+		require.True(t, result)
+	})
+
+	t.Run("should not recognize visit as legit if device is unknown", func(t *testing.T) {
+
+		// given
+		lastLegitVisit := detector.Visit[anythingGeoLocated]{}
+		currentVisit := detector.Visit[anythingGeoLocated]{
+			Time:        time.Now(),
+			DeviceId:    uuid.Must(uuid.NewV4()),
+			GeoLocation: "Location",
+		}
+		var knownDevices []uuid.UUID
+		visitsAggregateUT := NewVisitsAggregate(knownDevices, lastLegitVisit)
+
+		// when
+		result := visitsAggregateUT.IsLegitVisit(currentVisit)
+
+		// then
+		require.False(t, result)
+	})
+}
+
+type anythingGeoLocated string
+
+func (l anythingGeoLocated) IsGeoLocated() bool {
+	return l != ""
+}

--- a/session/impossibletravel/knowndevices/visitsaggregator.go
+++ b/session/impossibletravel/knowndevices/visitsaggregator.go
@@ -1,0 +1,52 @@
+package knowndevices
+
+import (
+	"github.com/gofrs/uuid"
+	"github.com/ory/kratos/session/impossibletravel/detector"
+	"slices"
+)
+
+type VisitsAggregator[T detector.GeoLocated] struct {
+	fakeStorage map[uuid.UUID]*VisitsAggregate[T]
+}
+
+func NewVisitsAggregator[T detector.GeoLocated]() *VisitsAggregator[T] {
+	return &VisitsAggregator[T]{}
+}
+
+func (a *VisitsAggregator[T]) GetPreviousVisitsAggregate(identityID uuid.UUID) (detector.PreviousVisitsAggregate[T], error) {
+	// FIXME read data stored for given Identity
+	visitsAggregate := a.fakeStorage[identityID]
+	return visitsAggregate, nil
+}
+
+func (a *VisitsAggregator[T]) AggregateVisit(identityID uuid.UUID, visit detector.Visit[T], detectionResult detector.DetectionResult) error {
+	// FIXME read data stored for given Identity and add new visit information
+	//  - preferable atomic/transactional operation so aggregates are not messed up in case of many simultaneous activities
+	//  - however maybe it's worth to consider also, that those are not very crucial data and loosing a single visit in aggregate may not be very harmful
+	// silly implementation just for sake of an example
+	if isLegit(detectionResult) {
+		aggregate, found := a.fakeStorage[identityID]
+		if found {
+			aggregate.lastLegitVisit = visit
+			// only unique entries
+			if !slices.Contains(aggregate.knownDeviceIds, visit.DeviceId) {
+				aggregate.knownDeviceIds = append(aggregate.knownDeviceIds, visit.DeviceId)
+			}
+		} else {
+			aggregate = NewVisitsAggregate(make([]uuid.UUID, 0), visit)
+			a.fakeStorage[identityID] = aggregate
+		}
+	}
+	return nil
+}
+
+func isLegit(detectionResult detector.DetectionResult) bool {
+	switch detectionResult {
+	case detector.LegitFirstVisit:
+	case detector.LegitVisit:
+	case detector.LegitTravel:
+		return true
+	}
+	return false
+}

--- a/session/impossibletravel/module.go
+++ b/session/impossibletravel/module.go
@@ -1,0 +1,18 @@
+package impossibletravel
+
+import (
+	"github.com/ory/kratos/session/impossibletravel/crosscountry"
+	"github.com/ory/kratos/session/impossibletravel/detector"
+	"github.com/ory/kratos/session/impossibletravel/knowndevices"
+)
+
+type Config struct {
+	// FIXME define config which allows to create wanted detector
+}
+
+func NewDetectorFrom(config Config) *detector.Detector[crosscountry.Country] {
+	// FIXME use configuration to create detector and it's deps
+	visitsAggregator := knowndevices.NewVisitsAggregator[crosscountry.Country]()
+	travelDurationEstimator := crosscountry.NewAvgAirplaneTravelsEstimator()
+	return detector.NewDetector(visitsAggregator, travelDurationEstimator)
+}

--- a/session/manager_http.go
+++ b/session/manager_http.go
@@ -5,6 +5,8 @@ package session
 
 import (
 	"context"
+	"github.com/ory/kratos/session/impossibletravel/crosscountry"
+	"github.com/ory/kratos/session/impossibletravel/detector"
 	"net/http"
 	"net/url"
 	"time"
@@ -42,6 +44,13 @@ import (
 
 var ErrNoAALAvailable = herodot.ErrForbidden.WithReasonf("Unable to detect available authentication methods. Perform account recovery or contact support.")
 
+type ImpossibleTravelDetector interface {
+	DetectImpossibleTravel(
+		identityID uuid.UUID,
+		currentVisit detector.Visit[crosscountry.Country],
+	) detector.DetectionResult
+}
+
 type (
 	managerHTTPDependencies interface {
 		config.Provider
@@ -55,6 +64,7 @@ type (
 		x.TransactionPersistenceProvider
 		PersistenceProvider
 		sessiontokenexchange.PersistenceProvider
+		ImpossibleTravelDetector
 	}
 	ManagerHTTP struct {
 		cookieName func(ctx context.Context) string
@@ -470,12 +480,24 @@ func (s *ManagerHTTP) ActivateSession(r *http.Request, session *Session, i *iden
 	session.ExpiresAt = authenticatedAt.Add(s.r.Config().SessionLifespan(ctx))
 	session.AuthenticatedAt = authenticatedAt
 
-	session.SetSessionDeviceInformation(r.WithContext(ctx))
+	currentDevice := session.SetSessionDeviceInformation(r.WithContext(ctx))
 	session.SetAuthenticatorAssuranceLevel()
+
+	currentVisit := createCurrentVisit(session, currentDevice)
+	// perform impossible travel detection and store result in a current session
+	session.ImpossibleTravelDetectionResult = s.r.DetectImpossibleTravel(i.ID, currentVisit)
 
 	span.SetAttributes(
 		attribute.String("identity.available_aal", session.Identity.InternalAvailableAAL.String),
 	)
 
 	return nil
+}
+
+func createCurrentVisit(session *Session, device Device) (visit detector.Visit[crosscountry.Country]) {
+	return detector.Visit[crosscountry.Country]{
+		Time:        session.CreatedAt,
+		DeviceId:    device.ID,
+		GeoLocation: device.GeoLocationCountry,
+	}
 }

--- a/session/session.go
+++ b/session/session.go
@@ -8,6 +8,8 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
+	"github.com/ory/kratos/session/impossibletravel/crosscountry"
+	"github.com/ory/kratos/session/impossibletravel/detector"
 	"net/http"
 	"strings"
 	"time"
@@ -57,6 +59,8 @@ type Device struct {
 
 	// Geo Location corresponding to the IP Address
 	Location *string `json:"location" faker:"ptr_geo_location" db:"location"`
+	// Country from Geo Location corresponding to the IP Address
+	GeoLocationCountry crosscountry.Country `json:"geoLocationCountry" faker:"geo_location_country" db:"geo_location_country"`
 
 	// Time of capture
 	CreatedAt time.Time `json:"-" faker:"-" db:"created_at"`
@@ -133,6 +137,12 @@ type Session struct {
 
 	// IdentityID is a helper struct field for gobuffalo.pop.
 	IdentityID uuid.UUID `json:"-" faker:"-" db:"identity_id"`
+
+	// Impossible Travel detection result.
+	//
+	// Indicates if session activity is flagged due to rapid geographical shifts deemed impossible.
+	// If set to "ImpossibleTravel" current session has been recognized as result of suspicious activity.
+	ImpossibleTravelDetectionResult detector.DetectionResult `json:"impossible_travel" db:"impossible_travel"`
 
 	// CreatedAt is a helper struct field for gobuffalo.pop.
 	CreatedAt time.Time `json:"-" faker:"-" db:"created_at"`
@@ -256,7 +266,7 @@ func NewInactiveSession() *Session {
 	}
 }
 
-func (s *Session) SetSessionDeviceInformation(r *http.Request) {
+func (s *Session) SetSessionDeviceInformation(r *http.Request) Device {
 	device := Device{
 		SessionID: s.ID,
 		IPAddress: pointerx.Ptr(httpx.ClientIP(r)),
@@ -277,6 +287,7 @@ func (s *Session) SetSessionDeviceInformation(r *http.Request) {
 	device.Location = pointerx.Ptr(strings.Join(clientGeoLocation, ", "))
 
 	s.Devices = append(s.Devices, device)
+	return device
 }
 
 func (s Session) Declassified() *Session {


### PR DESCRIPTION
Enables Kratos to detect visits, where an identity is accessed from two different geographic locations (eg countries) within an unreasonably short timeframe, suggesting that conventional travel between those locations would be impossible.

It is still Work In Progress, and it is NOT working solution. Further work needed is marked with FIXME comments in code.

It is also not fully integrated with existing code, however Impossible Travel Module is added to session ManagerHTTP component, where IMO it should be used.
